### PR TITLE
Improve installer and bump versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 logs/
 *.log
 vendor/
+data/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # agents.md
 
 **Projet : Virtual Portfolio Advisor & Alert System**  
-**Version : 1.0.1**  
+**Version : 1.0.2**  
 **Date : 2025-07-06**  
 **Auteur : [Ton nom ou pseudo]**
 
@@ -88,6 +88,13 @@ Le système est conçu pour suivre un portefeuille multi-actifs, générer des a
 | Notification Agent   | [ ]         | [x]         |             |
 | UI/Frontend Agent    | [x]         | [x]         | [ ]         |
 | Settings Manager     | [x]         | [x]         | [ ]         |
+
+---
+
+## Règles d'installation
+
+- Toutes les dépendances nécessaires (PHP, MySQL, extensions...) doivent être déclarées dans `install.sh`.
+- Le script d'installation doit se charger de leur installation avant la mise en place du projet.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Virtual Portfolio Advisor & Alert System
-<!-- Version: 0.1.1 - Date: 2025-07-06 -->
+<!-- Version: 0.1.3 - Date: 2025-07-06 -->
 
 ![Status](https://img.shields.io/badge/status-in%20development-orange)
 ![License](https://img.shields.io/github/license/votre-repo/portfolio-advisor)

--- a/admin/db_check.php
+++ b/admin/db_check.php
@@ -1,19 +1,69 @@
 <?php
 /**
  * DB Check Script
- * Version: 0.1.0
+ * Version: 0.2.1
  * Date: 2025-07-06
  */
 
-function checkDatabase() {
-    echo "Database check placeholder\n";
+const DB_FILE = __DIR__ . '/../data/portfolio.db';
+
+function checkDatabase(): bool {
+    return file_exists(DB_FILE);
+}
+
+function createDatabase(): bool {
+    $dir = dirname(DB_FILE);
+    if (!is_dir($dir) && !mkdir($dir, 0777, true)) {
+        echo "Failed to create data directory.\n";
+        return false;
+    }
+    try {
+        $db = new SQLite3(DB_FILE);
+        $db->exec('CREATE TABLE IF NOT EXISTS portfolio (id INTEGER PRIMARY KEY)');
+        $db->close();
+        return true;
+    } catch (Exception $e) {
+        echo "Error creating database: {$e->getMessage()}\n";
+        return false;
+    }
+}
+
+function interactiveSetup(): void {
+    if (checkDatabase()) {
+        echo "Database already exists.\n";
+        return;
+    }
+    echo "Database not found. Create it now? (y/n): ";
+    $answer = trim(fgets(STDIN));
+    if (strtolower($answer) === 'y') {
+        if (createDatabase()) {
+            echo "Database created successfully.\n";
+        } else {
+            echo "Database creation failed.\n";
+        }
+    } else {
+        echo "Database not created.\n";
+    }
 }
 
 if (php_sapi_name() === 'cli') {
-    if ($argc > 1 && $argv[1] === '--version') {
-        echo "db_check.php version 0.1.0\n";
+    if (in_array('--version', $argv)) {
+        echo "db_check.php version 0.2.1\n";
         exit(0);
     }
-    checkDatabase();
+    if (in_array('--create', $argv)) {
+        if (createDatabase()) {
+            echo "Database created successfully.\n";
+            exit(0);
+        }
+        echo "Database creation failed.\n";
+        exit(1);
+    }
+    if (checkDatabase()) {
+        echo "Database is present.\n";
+    } else {
+        echo "Database is missing.\n";
+        interactiveSetup();
+    }
 }
 ?>

--- a/changelog.md
+++ b/changelog.md
@@ -5,3 +5,9 @@
 - Added .gitignore to exclude logs, *.log and vendor directory.
 - Added LICENSE file with non-distribution notice.
 - Mentioned license in README.
+- Added interactive DB check and creation assistant in admin/db_check.php.
+- Installer now initializes DB and data directory. Uninstaller cleans data folder.
+- log_create.sh now sets up data directory. README version bumped to 0.1.2.
+- Installer now installs PHP and MySQL dependencies with debug logging.
+- Updated versions of db_check.php and install.sh.
+- AGENTS.md mis à jour à la version 1.0.2 avec les règles d\x27installation des dépendances.

--- a/install.sh
+++ b/install.sh
@@ -1,7 +1,17 @@
 #!/bin/bash
 # Project installer
-# Version: 0.1.0
+# Version: 0.1.2
 # Date: 2025-07-06
 
+LOG_FILE="logs/install.log"
+mkdir -p "$(dirname "$LOG_FILE")"
+exec > >(tee -a "$LOG_FILE") 2>&1
+set -x
+
+echo "Installing dependencies..."
+sudo apt-get update -y
+sudo apt-get install -y php php-sqlite3 mysql-server
+
 php src/portfolio_manager.php --install
+php admin/db_check.php --create
 ./tools/log_create.sh

--- a/remove.sh
+++ b/remove.sh
@@ -1,7 +1,8 @@
 #!/bin/bash
 # Project uninstaller
-# Version: 0.1.0
+# Version: 0.1.1
 # Date: 2025-07-06
 
 php src/portfolio_manager.php --remove
 rm -rf logs
+rm -rf data

--- a/tools/log_create.sh
+++ b/tools/log_create.sh
@@ -1,10 +1,12 @@
 #!/bin/bash
 # Log create script
-# Version: 0.1.0
+# Version: 0.1.1
 # Date: 2025-07-06
 
 LOG_DIR="logs"
+DATA_DIR="data"
 
 mkdir -p "$LOG_DIR"
+mkdir -p "$DATA_DIR"
 
 echo "Log directory initialized at $(date)" >> "$LOG_DIR/setup.log"


### PR DESCRIPTION
## Summary
- add debug logging and dependency install to `install.sh`
- bump version numbers in installer, DB check script and README
- document updated behavior in changelog
- clarify dependency rules in `AGENTS.md`

## Testing
- `php -v` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8bc1e610832c99fe8380025ddf4e