### PR TITLE
Add market data fetcher module

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,7 +1,7 @@
 # agents.md
 
 **Projet : Virtual Portfolio Advisor & Alert System**  
-**Version : 1.0.2**  
+**Version : 1.0.3**
 **Date : 2025-07-06**  
 **Auteur : [Ton nom ou pseudo]**
 
@@ -29,7 +29,7 @@ Le système est conçu pour suivre un portefeuille multi-actifs, générer des a
 | Agent                | Rôle principal                                      | Statut    |
 |----------------------|-----------------------------------------------------|-----------|
 | Portfolio Manager    | Gestion des positions et de l’historique            | [x] En cours |
-| Market Data Fetcher  | Récupération temps réel des prix et historiques     | [ ] À faire |
+| Market Data Fetcher  | Récupération temps réel des prix et historiques     | [x] En cours |
 | Alert Engine         | Génération d’alertes (selon règles customisées)     | [ ] À faire |
 | Recommendation Core  | Conseils d’achats/ventes pour l’allocation cible    | [ ] À faire |
 | Notification Agent   | Envoi de notifications (mail, browser, Telegram…)   | [ ] À faire |

--- a/changelog.md
+++ b/changelog.md
@@ -11,3 +11,6 @@
 - Installer now installs PHP and MySQL dependencies with debug logging.
 - Updated versions of db_check.php and install.sh.
 - AGENTS.md mis à jour à la version 1.0.2 avec les règles d\x27installation des dépendances.
+- Ajout du script market_data_fetcher.php avec options CLI et placeholder de prix.
+- Mise à jour d\'install.sh et remove.sh pour ce module.
+- Statut du Market Data Fetcher marqué "En cours" et AGENTS.md passé en version 1.0.3.

--- a/install.sh
+++ b/install.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # Project installer
-# Version: 0.1.2
+# Version: 0.1.3
 # Date: 2025-07-06
 
 LOG_FILE="logs/install.log"
@@ -13,5 +13,6 @@ sudo apt-get update -y
 sudo apt-get install -y php php-sqlite3 mysql-server
 
 php src/portfolio_manager.php --install
+php src/market_data_fetcher.php --install
 php admin/db_check.php --create
 ./tools/log_create.sh

--- a/remove.sh
+++ b/remove.sh
@@ -1,8 +1,9 @@
 #!/bin/bash
 # Project uninstaller
-# Version: 0.1.1
+# Version: 0.1.2
 # Date: 2025-07-06
 
 php src/portfolio_manager.php --remove
+php src/market_data_fetcher.php --remove
 rm -rf logs
 rm -rf data

--- a/src/market_data_fetcher.php
+++ b/src/market_data_fetcher.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Market Data Fetcher
+ * Version: 0.1.0
+ * Date: 2025-07-06
+ */
+
+const CONFIG_FILE = __DIR__ . '/../data/market_fetcher.conf';
+
+function install() {
+    if (!file_exists(CONFIG_FILE)) {
+        if (file_put_contents(CONFIG_FILE, "api_key=YOUR_KEY\n")) {
+            echo "Market Data Fetcher installed.\n";
+        } else {
+            echo "Failed to create config file.\n";
+        }
+    } else {
+        echo "Market Data Fetcher already installed.\n";
+    }
+}
+
+function remove() {
+    if (file_exists(CONFIG_FILE)) {
+        unlink(CONFIG_FILE);
+        echo "Market Data Fetcher removed.\n";
+    } else {
+        echo "Market Data Fetcher not installed.\n";
+    }
+}
+
+function fetch(string $symbol): float {
+    // Placeholder simulated price
+    $price = rand(100, 500) / 10;
+    echo "$symbol price: $price\n";
+    return $price;
+}
+
+if (php_sapi_name() === 'cli') {
+    global $argv;
+    if (in_array('--version', $argv)) {
+        echo "market_data_fetcher.php version 0.1.0\n";
+        exit(0);
+    }
+    if (in_array('--install', $argv)) {
+        install();
+        exit(0);
+    }
+    if (in_array('--remove', $argv)) {
+        remove();
+        exit(0);
+    }
+    if (isset($argv[1])) {
+        fetch($argv[1]);
+    } else {
+        echo "Usage: php market_data_fetcher.php SYMBOL [--install|--remove|--version]\n";
+    }
+}
+?>


### PR DESCRIPTION
## Summary
- introduce `market_data_fetcher.php` with install/remove and simple price fetch
- wire new script into installer and uninstaller
- flag Market Data Fetcher agent as "en cours"
- bump script versions and update changelog

## Testing
- `php -l src/market_data_fetcher.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686a8e9a9704832cb9f0db1223c937c5